### PR TITLE
Allow declarative config of OAuth2 component

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -6,3 +6,26 @@ var exports = module.exports = loopbackOAuth2;
 
 exports.oAuth2Provider = loopbackOAuth2; // Keep backward-compatibility
 exports.oauth2orize = require('./oauth2orize');
+
+/**
+ * A factory function for middleware handler that obtains the `authentication`
+ * handler configured by the OAuth2 component.
+ */
+exports.authenticate = function(options) {
+  var handler;
+  return function oauth2AuthenticateHandler(req, res, next) {
+    if (!handler) {
+      var app = req.app;
+      var authenticate = app._oauth2Handlers && app._oauth2Handlers.authenticate;
+
+      if (!authenticate) {
+        return next(new Error(
+          'The OAuth2 component was not configured for this application.'));
+      }
+
+      handler = authenticate(options);
+    }
+
+    return handler(req, res, next);
+  };
+}

--- a/lib/oauth2-loopback.js
+++ b/lib/oauth2-loopback.js
@@ -749,5 +749,7 @@ module.exports = function(app, options) {
         failureRedirect: options.loginPage || '/login' }));
   }
 
+  app._oauth2Handlers = handlers;
+
   return handlers;
 };


### PR DESCRIPTION
Implement a new middleware factory
`loopback-component-oauth2#authenticate` that can be configured
in `server/middleware.json` and which invokes the authentication
middleware created by `loopback-component-oauth2(app)`.

Modify the main exported function to store the list of OAuth2
handlers/endpoints on the app object, so that the new middleware can
retrieve it from there.

/to @raymondfeng please review

This is the Gateway configuration that works for me (I'll send a pull request shortly):

*server/component-config.json*

```json
{
  "loopback-component-oauth2": {
    "dataSource": "db",
    "loginPage": "/login",
    "loginPath": "/login"
  }
}
```

*server/middleware.json* (snippet)

```json
{
  "auth": {
    "loopback-component-oauth2#authenticate": {
      "paths": [
        "/protected",
        "/api",
        "/me"
      ],
      "params": {
        "session": false,
        "scope": "demo"
      }
    }
  }
}
```