### PR TITLE
Fix the oAuth2 auth middleware for an array of handlers

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -12,9 +12,9 @@ exports.oauth2orize = require('./oauth2orize');
  * handler configured by the OAuth2 component.
  */
 exports.authenticate = function(options) {
-  var handler;
+  var router;
   return function oauth2AuthenticateHandler(req, res, next) {
-    if (!handler) {
+    if (!router) {
       var app = req.app;
       var authenticate = app._oauth2Handlers && app._oauth2Handlers.authenticate;
 
@@ -23,9 +23,13 @@ exports.authenticate = function(options) {
           'The OAuth2 component was not configured for this application.'));
       }
 
-      handler = authenticate(options);
+      var handlers = authenticate(options);
+      router = app.loopback.Router();
+      for (var i = 0, n = handlers.length; i < n; i++) {
+        router.use(handlers[i]);
+      }
     }
 
-    return handler(req, res, next);
+    return router(req, res, next);
   };
 }


### PR DESCRIPTION
/to @bajtos 

The PR fixes an regression introduced by https://github.com/strongloop/loopback-component-oauth2/pull/9. Please note that there are an array of handlers behind `authenticate`.