### PR TITLE
check grant type of client requesting code or access token

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,7 @@ Contributing to `loopback-component-oauth2` is easy. In a few simple steps:
   * Adhere to code style outlined in the [Google C++ Style Guide][] and
     [Google Javascript Style Guide][].
 
-  * Sign the [Contributor License Agreement](https://cla.strongloop.com/strongloop/loopback-component-oauth2)
+  * Sign the [Contributor License Agreement](https://cla.strongloop.com/agreements/strongloop/loopback-component-oauth2)
 
   * Submit a pull request through Github.
 

--- a/lib/oauth2-loopback.js
+++ b/lib/oauth2-loopback.js
@@ -44,6 +44,24 @@ function isExpired(tokenOrCode) {
   return now > expirationTime;
 }
 
+function isAllowedGrantType(client, requestedType) {
+  if (!client.grantTypes) {
+    // this case allows all types
+    return true;
+  }
+
+  var allowed = false;
+  client.grantTypes.forEach(function (type) {
+    if (type == requestedType) {
+      debug('type matched: ', type);
+      allowed = true;
+      return true;
+    }
+  });
+  return allowed;
+}
+
+
 /**
  * Set up oAuth 2.0 strategies
  * @param {Object} app App instance
@@ -275,6 +293,10 @@ module.exports = function(app, options) {
     server.grant(oauth2Provider.grant.code(
       { allowsPost: options.allowsPostForAuthorization},
       function(client, redirectURI, user, scope, ares, done) {
+        if (!isAllowedGrantType(client, 'authorizationCode')) {
+          err = new Error('This type is not permitted to this client');
+          return done(err, null);
+        }
         var code = generateToken({
           grant: 'Authorization Code',
           client: client,
@@ -303,6 +325,11 @@ module.exports = function(app, options) {
       function(client, code, redirectURI, done) {
         debug('Verifying authorization code: %s %s %s',
           code, clientInfo(client), redirectURI);
+
+        if (!isAllowedGrantType(client, 'authorizationCode')) {
+          err = new Error('This type is not permitted to this client');
+          return done(err, null);
+        }
 
         models.authorizationCodes.findByCode(code, function(err, authCode) {
           if (err || !authCode) {
@@ -386,6 +413,11 @@ module.exports = function(app, options) {
         debug('Verifying username/password: %s %s %s',
           clientInfo(client), username, scope);
 
+        if (!isAllowedGrantType(client, 'resourceOwnerPasswordCredentials')) {
+          err = new Error('This type is not permitted to this client');
+          return done(err, null);
+        }
+
         userLogin(username, password, function(err, user) {
           if (err || !user) {
             return done(err, null);
@@ -426,6 +458,11 @@ module.exports = function(app, options) {
   if (supportedGrantTypes.indexOf('clientCredentials') !== -1) {
     server.exchange(oauth2Provider.exchange.clientCredentials(
       function(client, scope, done) {
+        if (!isAllowedGrantType(client, 'clientCredentials')) {
+          err = new Error('This type is not permitted to this client');
+          return done(err, null);
+        }
+
         var token = generateToken({
           grant: 'Client Credentials',
           client: client,
@@ -457,6 +494,10 @@ module.exports = function(app, options) {
   if (supportedGrantTypes.indexOf('refreshToken') !== -1) {
     server.exchange(oauth2Provider.exchange.refreshToken(
       function(client, refreshToken, scope, done) {
+        if (!isAllowedGrantType(client, 'refreshToken')) {
+          err = new Error('This type is not permitted to this client');
+          return done(err, null);
+        }
         models.accessTokens.findByRefreshToken(refreshToken,
           function(err, accessToken) {
             if (err || !accessToken) {
@@ -511,6 +552,10 @@ module.exports = function(app, options) {
     server.grant(oauth2Provider.grant.token(
       { allowsPost: options.allowsPostForAuthorization},
       function(client, user, scope, ares, done) {
+        if (!isAllowedGrantType(client, 'implicit')) {
+          err = new Error('This type is not permitted to this client');
+          return done(err, null);
+        }
         var token = generateToken({
           grant: 'Implicit',
           client: client,
@@ -532,8 +577,15 @@ module.exports = function(app, options) {
 
     server.exchange('urn:ietf:params:oauth:grant-type:jwt-bearer',
       oauth2Provider.exchange.jwt(function(client, jwtToken, done) {
-
+        if (!isAllowedGrantType(client, 'jwt')) {
+          err = new Error('This type is not permitted to this client');
+          return done(err, null);
+        }
         debug('Verifying JWT: %s %s', clientInfo(client), jwtToken);
+        if (client.grantType !== 'jwt-bearer') {
+            err = new Error('jwt-bearer type is not permitted to this client');
+            return done(err, null);
+        }
         var pub = client.publicKey;
         var decodedJWT;
         try {

--- a/lib/oauth2-loopback.js
+++ b/lib/oauth2-loopback.js
@@ -419,7 +419,23 @@ module.exports = function(app, options) {
         }
 
         userLogin(username, password, function(err, user) {
-          if (err || !user) {
+          if (err) {
+            debug('An error is reported from User.hasPassword: %j', err);
+            return done(err, false);
+          }
+
+          if (!matched) {
+            debug('The password is invalid for user %s', username);
+            err = new Error('password is not matched');
+            return done(err, false);
+          }
+
+          var User = app.loopback.getModelByType(app.loopback.User);
+          if (User.settings.emailVerificationRequired
+                && !user.emailVerified) {
+            // Fail to log in if email verification is not done yet
+            debug('User email has not been verified');
+            err = new Error('login failed as the email has not been verified');
             return done(err, null);
           }
           var token = generateToken({


### PR DESCRIPTION
Authentication server needs to check grant type of client when it request authorization code or access token.
if instance of 'Application' model for the client has 'grantTypes' property, authentication server check if requested type is allowed.

Additionally, I add another patch checking user data regarding email verification.