### PR TITLE
apply housekeep logic and use mongo ttl to kill accesstoken

### DIFF
--- a/common/models/ttl-token.json
+++ b/common/models/ttl-token.json
@@ -1,0 +1,67 @@
+{
+  "name": "TTLAccessToken",
+  "base": "PersistedModel",
+  "properties": {
+    "id": {
+      "type": "string",
+      "id": true,
+      "length": 300,
+      "generated": false
+    },
+    "appId": {
+      "type": "string",
+      "length": 128,
+      "index": true
+    },
+    "userId": {
+      "type": "string",
+      "index": true
+    },
+    "issuedAt": {
+      "type": "date",
+      "index": {
+       "expireAfterSeconds": 30
+     }
+    },
+    "expiresIn": "number",
+    "expiredAt": {
+      "type": "date",
+      "index": true
+    },
+    "scopes": [ "string" ],
+    "parameters": [
+      {
+        "name": "string",
+        "value": "string"
+      }
+    ],
+    "authorizationCode": {
+      "type": "string",
+      "length": 300,
+      "index": true
+    },
+    "refreshToken": {
+      "type": "string",
+      "length": 300,
+      "index": true
+    },
+    "tokenType": {
+      "type": "string",
+      "enum": [ "Bearer", "MAC" ]
+    },
+    "hash": "string"
+  },
+  "relations": {
+    "application": {
+      "type": "belongsTo",
+      "model": "OAuthClientApplication",
+      "foreignKey": "appId"
+    },
+    "user": {
+      "type": "belongsTo",
+      "model": "User",
+      "foreignKey": "userId"
+    }
+  }
+}
+

--- a/lib/models/index.js
+++ b/lib/models/index.js
@@ -25,6 +25,7 @@ module.exports = function(app, options) {
   debug('Application model: %s', applicationModel.modelName);
 
   var oAuthTokenModel = oauth2.OAuthToken;
+  var ttlTokenModel = oauth2.TTLToken;
   var oAuthAuthorizationCodeModel = oauth2.OAuthAuthorizationCode;
   var oAuthPermissionModel = oauth2.OAuthPermission;
 
@@ -106,7 +107,9 @@ module.exports = function(app, options) {
 
   var token = {};
   token.find = function(accessToken, done) {
-    oAuthTokenModel.findOne({where: {
+    //change the logic to find token in TTL table when checking the accesstoken
+    ttlTokenModel.findOne({where: {
+   // oAuthTokenModel.findOne({where: {
       id: accessToken
     }}, done);
   };
@@ -126,10 +129,13 @@ module.exports = function(app, options) {
     } else {
       where.refreshToken = token;
     }
+    //change the logic on delete token (renew), remove record in both ttl and oauth model
+    ttlTokenModel.destroyAll(where);
     oAuthTokenModel.destroyAll(where, done);
   };
 
   token.save = function(token, clientId, resourceOwner, scopes, refreshToken, done) {
+    
     var tokenObj;
     if (arguments.length === 2 && typeof token === 'object') {
       // save(token, cb)
@@ -151,6 +157,8 @@ module.exports = function(app, options) {
     tokenObj.expiresIn = ttl;
     tokenObj.issuedAt = new Date();
     tokenObj.expiredAt = new Date(tokenObj.issuedAt.getTime() + ttl * 1000);
+    //we save the tokenObj in both ttlTokenModel and OauthTokenModel
+    ttlTokenModel.create(tokenObj); //new ttlToken
     oAuthTokenModel.create(tokenObj, done);
   };
 
@@ -244,6 +252,7 @@ module.exports = function(app, options) {
     users: customModels.users || users,
     clients: customModels.clients || clients,
     accessTokens: customModels.accessTokens || token,
+    ttlTokens: customModels.ttlTokens || token,
     authorizationCodes: customModels.authorizationCodes || code,
     permissions: customModels.permission || permission
   };

--- a/lib/models/oauth2-models.js
+++ b/lib/models/oauth2-models.js
@@ -7,7 +7,9 @@ var permissionDef =
   require('../../common/models/oauth-permission.json');
 var scopeDef =
   require('../../common/models/oauth-scope.json');
-
+  // ttl token uses MongoDB ttl function on adding index of expireAfterSeconds
+  // we only need to kill accesstoken by ttl but keep refresh token forever.
+var ttlDef = require('../../common/models/ttl-token.json');
 var scopeMappingDef =
   require('../../common/models/oauth-scope-mapping.json');
 
@@ -29,6 +31,9 @@ module.exports = function(dataSource) {
   // "OAuth token"
   var OAuthToken = dataSource.createModel(
     tokenDef.name, tokenDef.properties, getSettings(tokenDef));
+  // "TTL token"
+   var TTLToken = dataSource.createModel(
+   ttlDef.name, ttlDef.properties, getSettings(ttlDef));
 
   // "OAuth authorization code"
   var OAuthAuthorizationCode = dataSource.createModel(
@@ -62,6 +67,7 @@ module.exports = function(dataSource) {
 
   return {
     OAuthToken: OAuthToken,
+    TTLToken: TTLToken,
     OAuthAuthorizationCode: OAuthAuthorizationCode,
     OAuthClientApplication: OAuthClientApplication,
     OAuthPermission: OAuthPermission,

--- a/lib/oauth2-loopback.js
+++ b/lib/oauth2-loopback.js
@@ -436,9 +436,15 @@ module.exports = function(app, options) {
 
             debug('Generating access token: %j %s %s %j',
               token, clientInfo(client), scope, refreshToken);
-
-            models.accessTokens.save(token.id, client.id, accessToken.userId,
-              scope, refreshToken, getTokenHandler(token, done));
+            //edit the logic on how to store new token set after refreshing token
+            //wrap the save function by delete function.
+            models.accessTokens.delete(client.id, accessToken.id, 'access_token', function(err){
+             if (err) {
+               return done(err);
+               }
+               models.accessTokens.save(token.id, client.id, accessToken.userId,
+                 scope, refreshToken, getTokenHandler(token, done));
+            });
           });
       }));
   }


### PR DESCRIPTION
By loopback oauth2 component default setting, there is a big problem that the records in OAuthAccessToken Table will be accumulated when using refresh token to renew the access token.
It causes following problems:
The records in tabel accumulated by time
the old refresh tokens are still valid.
the old access token are still valid until expiry time.
More than one access token may be valid for same device at same time

So, we try to edit the logic on how to store new token set after refreshing token

Consider the TTL function in mongoDB, refer to Expire Data from Collections by Setting TTL
We can set an sparse index to tell mongodb to housekeep the records, preventing accumulation occurs.
we apply expireAfterSeconds index on issuedAt. (The old expiredAt field becomes useless)

we revise the logic on
how to save Access Token
how to check Access Token
how to renew Access Token 
how to revoke Access Token
