### PR TITLE
Fix deprecation warnings.

### DIFF
--- a/lib/oauth2-loopback.js
+++ b/lib/oauth2-loopback.js
@@ -23,7 +23,8 @@ var url = require('url'),
   LocalStrategy = require('passport-local').Strategy,
   BasicStrategy = require('passport-http').BasicStrategy,
   ClientPasswordStrategy = require('passport-oauth2-client-password').Strategy,
-  ClientJWTBearerStrategy = require('./strategy/jwt-bearer').Strategy;
+  ClientJWTBearerStrategy = require('./strategy/jwt-bearer').Strategy,
+  bodyParser = require('body-parser');
 
 var clientInfo = helpers.clientInfo;
 var userInfo = helpers.userInfo;
@@ -781,8 +782,8 @@ module.exports = function(app, options) {
     options.loginPath || '/login',
   ];
   app.middleware('parse', oauth2Paths,
-    app.loopback.urlencoded({extended: false}));
-  app.middleware('parse', oauth2Paths, app.loopback.json({strict: false}));
+    bodyParser.urlencoded({extended: false}));
+  app.middleware('parse', oauth2Paths, bodyParser.json({strict: false}));
 
   // Set up the oAuth 2.0 protocol endpoints
   if (options.authorizePath !== false) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "loopback-component-oauth2",
-  "version": "2.4.1",
+  "version": "2.4.2",
   "description": "OAuth 2.0 provider for LoopBack",
   "keywords": [
     "StrongLoop",
@@ -25,6 +25,7 @@
   "main": "./lib",
   "dependencies": {
     "async": "^1.5.2",
+    "body-parser": "^1.15.2",
     "connect-ensure-login": "^0.1.1",
     "debug": "^2.2.0",
     "jws": "^3.0.0",


### PR DESCRIPTION
LoopBack deprecated `urlencoded` and `json`, and suggests using **body-parser** (https://github.com/strongloop/loopback/blob/v2.31.0/lib/express-middleware.js#L46-L51). Since LoopBack was already using body-parser for these functions, this is a simple 1-1 replacement.