### PR TITLE
support configuring paths and exclusions

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -12,6 +12,7 @@ var SG = require('strong-globalize');
 SG.SetRootDir(path.join(__dirname, '..'));
 var g = SG();
 var loopbackOAuth2 = require('./oauth2-loopback');
+var utils = require('./utils');
 var exports = module.exports = loopbackOAuth2;
 
 exports.oAuth2Provider = loopbackOAuth2; // Keep backward-compatibility
@@ -24,22 +25,28 @@ exports.oauth2orize = require('./oauth2orize');
 exports.authenticate = function(options) {
   var router;
   return function oauth2AuthenticateHandler(req, res, next) {
-    if (!router) {
-      var app = req.app;
-      var authenticate = app._oauth2Handlers && app._oauth2Handlers.authenticate;
+    utils.shouldUse(req, options, function(testResult) {
+      if (testResult) {
+        if (!router) {
+          var app = req.app;
+          var authenticate = app._oauth2Handlers && app._oauth2Handlers.authenticate;
 
-      if (!authenticate) {
-        return next(new Error(g.f(
-          'The {{OAuth2}} component was not configured for this application.')));
+          if (!authenticate) {
+            return next(new Error(g.f(
+              'The {{OAuth2}} component was not configured for this application.')));
+          }
+
+          var handlers = authenticate(options);
+          router = app.loopback.Router();
+          for (var i = 0, n = handlers.length; i < n; i++) {
+            router.use(handlers[i]);
+          }
+        }
+
+        return router(req, res, next);
+      } else {
+        return next();
       }
-
-      var handlers = authenticate(options);
-      router = app.loopback.Router();
-      for (var i = 0, n = handlers.length; i < n; i++) {
-        router.use(handlers[i]);
-      }
-    }
-
-    return router(req, res, next);
+    });
   };
 };

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -9,6 +9,8 @@ exports.uid = require('uid2');
 
 exports.shouldUse = function(req, options, done) {
   if (!options.paths) return done(true); // Keep backward-compatibility
+  if (req.headers.authorization) return done(true);
+
   if (options.paths.constructor !== Array) {
     options.paths = [options.paths];
   }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -43,15 +43,19 @@ exports.shouldUse = function(req, options, done) {
         test = false;
         break;
       } else if (exclude[i].constructor === Object) {
-        if (exclude[i].method && exclude[i].path &&
-          exclude[i].method.toLowerCase() === method &&
-          new RegExp(exclude[i].path, 'i').test(path)) {
-          test = false;
-          break;
-        } else if (exclude[i].path &&
-          new RegExp(exclude[i].path, 'i').test(path)) {
-          test = false;
-          break;
+        if (exclude[i].method) {
+          if (exclude[i].path &&
+            exclude[i].method.toLowerCase() === method &&
+            new RegExp(exclude[i].path, 'i').test(path)) {
+            test = false;
+            break;
+          }
+        } else {
+          if (exclude[i].path &&
+            new RegExp(exclude[i].path, 'i').test(path)) {
+            test = false;
+            break;
+          }
         }
       }
     }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -20,11 +20,11 @@ exports.shouldUse = function(req, options, done) {
 
   for (var i = 0, n = options.paths.length; i < n; i++) {
     if ((options.paths[i].constructor === String || options.paths[i].constructor === RegExp) &&
-      new RegExp(options.paths[i], 'i').test(path)) {
+      new RegExp('^' + options.paths[i], 'i').test(path)) {
       test = true;
       break;
     } else if (options.paths[i].constructor === Object &&
-      new RegExp(options.paths[i].path, 'i').test(path)) {
+      new RegExp('^' + options.paths[i].path, 'i').test(path)) {
       test = true;
       if (typeof options.paths[i].exclude !== 'undefined') {
         exclude = options.paths[i].exclude;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -6,3 +6,56 @@
 'use strict';
 exports.merge = require('utils-merge');
 exports.uid = require('uid2');
+
+exports.shouldUse = function(req, options, done) {
+  if (!options.paths) return done(true); // Keep backward-compatibility
+  if (options.paths.constructor !== Array) {
+    options.paths = [options.paths];
+  }
+
+  var method = req.method.toLowerCase();
+  var path = req._parsedUrl.pathname;
+  var test = false;
+  var exclude = false;
+
+  for (var i = 0, n = options.paths.length; i < n; i++) {
+    if ((options.paths[i].constructor === String || options.paths[i].constructor === RegExp) &&
+      new RegExp(options.paths[i], 'i').test(path)) {
+      test = true;
+      break;
+    } else if (options.paths[i].constructor === Object &&
+      new RegExp(options.paths[i].path, 'i').test(path)) {
+      test = true;
+      if (typeof options.paths[i].exclude !== 'undefined') {
+        exclude = options.paths[i].exclude;
+      }
+      break;
+    }
+  }
+
+  if (exclude) {
+    if (exclude.constructor !== Array) {
+      exclude = [exclude];
+    }
+    for (var i = 0, n = exclude.length; i < n; i++) {
+      if ((exclude[i].constructor === String || exclude[i].constructor === RegExp) &&
+        new RegExp(exclude[i], 'i').test(path)) {
+        test = false;
+        break;
+      } else if (exclude[i].constructor === Object) {
+        if (exclude[i].method && exclude[i].path &&
+          exclude[i].method.toLowerCase() === method &&
+          new RegExp(exclude[i].path, 'i').test(path)) {
+          test = false;
+          break;
+        } else if (exclude[i].path &&
+          new RegExp(exclude[i].path, 'i').test(path)) {
+          test = false;
+          break;
+        }
+      }
+    }
+  }
+
+  return done(test);
+};

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -1,0 +1,189 @@
+// Copyright IBM Corp. 2013. All Rights Reserved.
+// Node module: loopback-component-oauth2
+// US Government Users Restricted Rights - Use, duplication or disclosure
+// restricted by GSA ADP Schedule Contract with IBM Corp.
+
+'use strict';
+var utils = require('../lib/utils');
+
+describe('shouldUse', function() {
+  it('should preserve backward compatibility', function() {
+    var req = {
+      method: 'GET',
+      _parsedUrl: {
+        pathname: '/api/users',
+      },
+    };
+    var options = {};
+
+    utils.shouldUse(req, options, function(testResult) {
+      expect(testResult).to.be.true;
+    });
+  });
+
+  it('should support passing a string to paths', function() {
+    var req = {
+      method: 'GET',
+      _parsedUrl: {
+        pathname: '/api/users',
+      },
+    };
+    var options = {
+      paths: '/api',
+    };
+
+    utils.shouldUse(req, options, function(testResult) {
+      expect(testResult).to.be.true;
+    });
+  });
+
+  it('should support passing a regex to paths', function() {
+    var req = {
+      method: 'GET',
+      _parsedUrl: {
+        pathname: '/api/users',
+      },
+    };
+    var options = {
+      paths: /api/,
+    };
+
+    utils.shouldUse(req, options, function(testResult) {
+      expect(testResult).to.be.true;
+    });
+  });
+
+  it('should support passing an array of strings to paths', function() {
+    var req = {
+      method: 'GET',
+      _parsedUrl: {
+        pathname: '/api/users',
+      },
+    };
+    var options = {
+      paths: [/api/],
+    };
+
+    utils.shouldUse(req, options, function(testResult) {
+      expect(testResult).to.be.true;
+    });
+  });
+
+  it('should support passing an array of objects to paths', function() {
+    var req = {
+      method: 'GET',
+      _parsedUrl: {
+        pathname: '/api/users',
+      },
+    };
+    var options = {
+      paths: [{
+        path: '/api',
+      }],
+    };
+
+    utils.shouldUse(req, options, function(testResult) {
+      expect(testResult).to.be.true;
+    });
+  });
+
+  it('should support passing a string to exclude', function() {
+    var req = {
+      method: 'GET',
+      _parsedUrl: {
+        pathname: '/api/users',
+      },
+    };
+    var options = {
+      paths: [{
+        path: '/api',
+        exclude: 'users',
+      }],
+    };
+    utils.shouldUse(req, options, function(testResult) {
+      expect(testResult).to.be.false;
+    });
+  });
+
+  it('should support passing a regex to exclude', function() {
+    var req = {
+      method: 'GET',
+      _parsedUrl: {
+        pathname: '/api/users',
+      },
+    };
+    var options = {
+      paths: [{
+        path: '/api',
+        exclude: /users/,
+      }],
+    };
+
+    utils.shouldUse(req, options, function(testResult) {
+      expect(testResult).to.be.false;
+    });
+  });
+
+  it('should support passing an object to exclude', function() {
+    var req = {
+      method: 'GET',
+      _parsedUrl: {
+        pathname: '/api/users',
+      },
+    };
+    var options = {
+      paths: [{
+        path: '/api',
+        exclude: {
+          method: 'GET',
+          path: 'users',
+        },
+      }],
+    };
+
+    utils.shouldUse(req, options, function(testResult) {
+      expect(testResult).to.be.false;
+    });
+  });
+
+  it('should support passing a array of rules to exclude', function() {
+    var req = {
+      method: 'GET',
+      _parsedUrl: {
+        pathname: '/api/users',
+      },
+    };
+    var options = {
+      paths: [{
+        path: '/api',
+        exclude: [
+          /app/,
+          {
+            method: 'GET',
+            path: 'users',
+          },
+        ],
+      }],
+    };
+
+    utils.shouldUse(req, options, function(testResult) {
+      expect(testResult).to.be.false;
+    });
+  });
+
+  it('should exclude unrelated paths', function() {
+    var req = {
+      method: 'GET',
+      _parsedUrl: {
+        pathname: '/api/users',
+      },
+    };
+    var options = {
+      paths: '/app',
+    };
+
+    utils.shouldUse(req, options, function(testResult) {
+      expect(testResult).to.be.false;
+    });
+  });
+});


### PR DESCRIPTION
### Description

Make it possible to configure paths and exclusion rules.

```
var auth = oauth2.authenticate({
  session: false,
  scope: ['email', 'public_profile', 'user'],
  paths: [
    {
      path: '/api',
      exclude: [
        /users\/?(login|register|reset)/,
        {
          method: 'GET',
          path: '(users|apps)$'
        }
      ]
    }
  ]
});
```

#### Related issues

https://github.com/strongloop/loopback/issues/2337

### Checklist

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
