### PR TITLE
Differentiate redirect uri to tell a failed login

### DIFF
--- a/lib/oauth2-loopback.js
+++ b/lib/oauth2-loopback.js
@@ -828,7 +828,7 @@ module.exports = function(app, options) {
     app.post(options.loginPath || '/login',
       passport.authenticate('loopback-oauth2-local',
       {successReturnToOrRedirect: '/',
-        failureRedirect: options.loginPage || '/login'}));
+        failureRedirect: options.loginPage + '?loginFailed' || '/login'}));
   }
 
   return handlers;


### PR DESCRIPTION
### Description

There is no options passed in when authenticating with local strategy. A minimum-change solution is to append "?loginFailed" to the end of failureRedirect uri when login failed (and leave blank if it is a normal login.)

This did the same with #33 . Just hoping it get merged because it is really annoying.

#### Related issues

#21 

### Checklist

- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
