### PR TITLE
This change is the addition of an option called "oauthACLgateway".

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@ npm-debug.log
 
 # Mac OS X
 .DS_Store
+
+# Jetbrains IDEs
+.idea

--- a/README.md
+++ b/README.md
@@ -1,5 +1,85 @@
 # loopback-component-oauth2
 
+## What is different in this fork?
+
+Apart from this readme, there has been a change to the lib index. This change is the addition of an option called "oauthACLgateway".
+
+If **oauthACLgateway** is *true*, we will check if the *access_token* provided (to query or body) is a user token. If the token is a user token (exists in AccessToken model), we skip oauth authentication.
+If no token is provided, we skip oauth authentication. Finally, if the option is omitted or false, the module will work as the original.
+
+### How to use
+
+Put something like this in your middleware.json:
+
+```json
+"auth": {
+    "loopback-component-oauth2#authenticate": { "paths" : ["/api"], "params": [{
+      "oauthACLgateway" : true,
+      "scopes": {
+        "read_only": [
+          {
+            "methods": "get",
+            "path": "/api"
+          }
+        ],
+        "write_only": [
+          {
+            "methods": "post",
+            "path": "/api"
+          }
+        ],
+        "read_write": [
+          {
+            "methods": ["get","post"],
+            "path": "/api"
+          }
+        ],
+        "all": [
+          {
+            "methods": "all",
+            "path": "/api"
+          }
+        ]
+      }
+    }] }
+  },
+```
+
+Additionally you will need to put the settings in the component-config.json. Here is the one we use as an example:
+
+```json
+"loopback-component-oauth2": {
+    "dataSource": "db",
+    "resourceServer": true,
+    "authorizationServer": true,
+    "loginPage": "/loginOauth",
+    "loginPath": "/loginOauthStep2",
+    "tokenPath": "/oauth/token"
+  },
+```
+
+Finally, we put this in our loopback server.js after the boot function call:
+
+```js
+let options = {
+  dataSource: app.dataSources.db, // Data source for oAuth2 metadata persistence
+  resourceServer: true,
+  authorizationServer: true,
+  loginPage: '/loginOauth', // The login page URL
+  loginPath: '/loginOauthStep2', // The login form processing URL
+  tokenPath: "/oauth/token",
+};
+
+oauth2.oAuth2Provider(
+  app, // The app instance
+  options // The options
+);
+```
+
+That's it! Enjoy!
+
+## From the original repo:
+
 The LoopBack oAuth 2.0 component provides full integration between [OAuth 2.0](http://tools.ietf.org/html/rfc6749)
 and [LoopBack](http://loopback.io). It enables LoopBack applications to function
 as an oAuth 2.0 provider to authenticate and authorize client applications and/or

--- a/lib/index.js
+++ b/lib/index.js
@@ -48,9 +48,9 @@ exports.authenticate = function (options) {
       }
     }
 
-    // if we did not explicitly enable the side by side option
-    let sideBySideEnabled = options && options.sideBySide || false;
-    if (sideBySideEnabled !== true) {
+    // if we did not explicitly enable the oauthACLgatewayEnabled option
+    let oauthACLgatewayEnabledEnabled = options && options.oauthACLgatewayEnabled || false;
+    if (oauthACLgatewayEnabledEnabled !== true) {
       return router(req, res, next);
     }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -49,8 +49,8 @@ exports.authenticate = function (options) {
     }
 
     // if we did not explicitly enable the oauthACLgatewayEnabled option
-    let oauthACLgatewayEnabledEnabled = options && options.oauthACLgatewayEnabled || false;
-    if (oauthACLgatewayEnabledEnabled !== true) {
+    let oauthACLgatewayEnabled = options && options.oauthACLgateway || false;
+    if (oauthACLgatewayEnabled !== true) {
       return router(req, res, next);
     }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -20,26 +20,82 @@ exports.oauth2orize = require('./oauth2orize');
 /**
  * A factory function for middleware handler that obtains the `authentication`
  * handler configured by the OAuth2 component.
+ *
+ * @param { Object } [options]   // possible options: { oauthACLgateway : Boolean }
+ *                               // if oauthACLgateway is true, we will check if the token provided is a user token.
+ *                               //  |_ if the token is a user accesstoken (exists in AccessToken model), we skip oauth authentication
+ *                               //  |_ if no token is provided, we skip oauth authentication
+ *                               // if it is false, the oauth module will work as normal.
  */
-exports.authenticate = function(options) {
-  var router;
-  return function oauth2AuthenticateHandler(req, res, next) {
-    if (!router) {
-      var app = req.app;
-      var authenticate = app._oauth2Handlers && app._oauth2Handlers.authenticate;
+exports.authenticate = function (options) {
+  let router;
 
+  // keep track of the tokens we have handled before so we do not need to query for every request.
+  let inMemoryTokenList = {};
+  return function oauth2AuthenticateHandler(req, res, next) {
+
+    if (!router) {
+      let app = req.app;
+      let authenticate = app._oauth2Handlers && app._oauth2Handlers.authenticate;
       if (!authenticate) {
-        return next(new Error(g.f(
-          'The {{OAuth2}} component was not configured for this application.')));
+        return next(new Error(g.f('The {{OAuth2}} component was not configured for this application.')));
       }
 
-      var handlers = authenticate(options);
+      let handlers = authenticate(options);
       router = app.loopback.Router();
-      for (var i = 0, n = handlers.length; i < n; i++) {
+      for (let i = 0, n = handlers.length; i < n; i++) {
         router.use(handlers[i]);
       }
     }
 
-    return router(req, res, next);
+    // if we did not explicitly enable the side by side option
+    let sideBySideEnabled = options && options.sideBySide || false;
+    if (sideBySideEnabled !== true) {
+      return router(req, res, next);
+    }
+
+    // if we do not have an access_token, do not use oauth2 to authenticate this request.
+    let accessToken = (req && (req.body && req.body.access_token) || (req.query && req.query.access_token)) || null;
+    if (!accessToken) {
+      next();
+      return;
+    }
+
+    // We keep a map of accessTokens to make sure we do not query the same token over and over.
+    // We keep the tokens alive for an hour, postponing them on each request.
+    if (inMemoryTokenList[accessToken] === undefined) {
+      inMemoryTokenList[accessToken] = {removalTimeout: null, isUserToken: null};
+    }
+    else if (inMemoryTokenList[accessToken].removalTimeout) {
+      // remove the pending timeout so we can set a new one.
+      clearTimeout(inMemoryTokenList[accessToken].removalTimeout);
+    }
+
+    // set a new timeout to remove this token from the inMemoryTokenList to make sure we do not keep an ever growing list.
+    inMemoryTokenList[accessToken].removalTimeout = setTimeout(() => { inMemoryTokenList[accessToken] = undefined; delete inMemoryTokenList[accessToken]; }, 3600000 ); // remove reference after one hour
+
+    // if we have seen this token before and if it turns out to be a user token, we skip the oauth authentication.
+    if (inMemoryTokenList[accessToken].isUserToken === true) {
+      next();
+      return;
+    }
+    else if (inMemoryTokenList[accessToken].isUserToken === false) {
+      return router(req, res, next);
+    }
+
+    let accessTokenModel = req.app.loopback.getModel("AccessToken");
+    // if we use promises insteade of the callback, the context is lost and the loopback-component-access-groups middleware fails to do it's thing.
+    accessTokenModel.findById(accessToken, function (err, token) {
+      // if the token is not found, it is null. If it is not in the user AccessToken model, we let oauth handle it.
+      if (token === null || err) {
+        inMemoryTokenList[accessToken].isUserToken = false;
+        return router(req, res, next);
+      }
+      else {
+        // the token belongs to a user, we skip the oauth step.
+        inMemoryTokenList[accessToken].isUserToken = true;
+        next();
+      }
+    });
   };
-};
+}; 


### PR DESCRIPTION
Hi, I'm not sure if you're interested in this but I needed it for our project. I have appended the README.md to reflect the changes. 

If **oauthACLgateway** is *true*, we will check if the *access_token* provided (to query or body) is a user token. If the token is a user token (exists in AccessToken model), we skip oauth authentication.
If no token is provided, we skip oauth authentication. Finally, if the option is omitted or false, the module will work as the original.



#### Related issues

<!--
Please use the following link syntaxes:

- #49 (to reference issues in the current repository)
- strongloop/loopback#49 (to reference issues in another repository)
-->

- None

### Checklist

<!--
Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
-->

- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
