### PR TITLE
update node version in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 language: "node_js"
 node_js:
-  - "0.10"
-  - "0.8"
+  - "4"
+  - "6"
+  - "8"
 
 before_install:
  - "npm install istanbul -g"


### PR DESCRIPTION
For the current version of LB, we are only supporting node version 4+.  Therefore, this PR is to update the node version in `.travis.yml`.