### PR TITLE
passport initialisation optional

### DIFF
--- a/lib/oauth2-loopback.js
+++ b/lib/oauth2-loopback.js
@@ -18,13 +18,14 @@ const url = require('url'),
   MacTokenGenerator = require('./mac-token'),
   modelBuilder = require('./models/index'),
   debug = require('debug')('loopback:oauth2'),
-  passport = require('passport'),
   login = require('connect-ensure-login'),
   LocalStrategy = require('passport-local').Strategy,
   BasicStrategy = require('passport-http').BasicStrategy,
   ClientPasswordStrategy = require('passport-oauth2-client-password').Strategy,
   ClientJWTBearerStrategy = require('./strategy/jwt-bearer').Strategy,
   bodyParser = require('body-parser');
+
+let passport = require('passport');
 
 const clientInfo = helpers.clientInfo;
 const userInfo = helpers.userInfo;

--- a/lib/oauth2-loopback.js
+++ b/lib/oauth2-loopback.js
@@ -53,10 +53,15 @@ module.exports = function(app, options) {
   // Default to true
   const session = (options.session !== false);
 
-  app.middleware('auth:before', passport.initialize());
-  if (session) {
-    app.middleware('auth', passport.session());
+  if (options.passport) {
+    passport = options.passport;
+  } else {
+    app.middleware('auth:before', passport.initialize());
+    if (session) {
+      app.middleware('auth', passport.session());
+    }
   }
+  module.exports.passport = passport;
 
   if (options.resourceServer !== false) {
     handlers.authenticate = setupResourceServer(app, options, models, true);


### PR DESCRIPTION
### Description

Passport is designed to be modular, it's better not to assume loopback-component-oauth2 will be initializing it unless you are giving it it's own instance using new passport.Passport(). This modification means you can pass in an existing passport that is assumed to be initialized, and then also export it so it can be modified. I know that passport is a singleton, but if you call initialize twice you can end up with bugs because there could be two instances flying around. 

I have signed the CLA and the message is under 50 characters this time :-)

#### Related issues

<!--
Please use the following link syntaxes:

- connect to #49 (to reference issues in the current repository)
- connect to strongloop/loopback#49 (to reference issues in another repository)
-->

- connect to <link_to_referenced_issue>

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
