### PR TITLE
Using Loopback recommended approach to exclude properties from the base model.

### DIFF
--- a/common/models/oauth-client-application.json
+++ b/common/models/oauth-client-application.json
@@ -1,6 +1,15 @@
 {
   "name": "OAuthClientApplication",
   "base": "Application",
+  "excludeBaseProperties": [
+    "callbackUrls",
+    "permissions",
+    "authenticationEnabled",
+    "anonymousAllowed",
+    "authenticationSchemes",
+    "icon",
+    "url"
+  ],
   "properties": {
     "id": {
       "type": "string",
@@ -52,15 +61,7 @@
       }
     },
     "softwareId": "string",
-    "softwareVersion": "string",
-
-    "callbackUrls": null,
-    "permissions": null,
-    "authenticationEnabled": null,
-    "anonymousAllowed": null,
-    "authenticationSchemes": null,
-    "icon": null,
-    "url": null
+    "softwareVersion": "string"
   },
   "comments": "https://tools.ietf.org/html/draft-ietf-oauth-dyn-reg-24"
 }


### PR DESCRIPTION
### Description

Fields which were excluded by setting them null in the model json file were still included into the select expression in the query. 
That was generating broken sql queries because fields were physically absent in the database (expected):

`STATEMENT:  SELECT "id","clienttype","redirecturis","tokenendpointauthmethod","granttypes","responsetypes","tokentype","clientsecret","clientname","clienturi","logouri","scopes","contacts","tosuri","policyuri","jwksuri","jwks","softwareid","softwareversion","realm","name","description","owner","collaborators","email","emailverified","clientkey","javascriptkey","restapikey","windowskey","masterkey","pushsettings","status","created","modified","icon","url","callbackurls","permissions","authenticationenabled","anonymousallowed","authenticationschemes" FROM "public"."oauthclientapplication" WHERE "id"=$1 ORDER BY "id" LIMIT 1`

Using the recommended Loopback approach to exclude properties from the base model fixed the issue for me.
https://loopback.io/doc/en/lb3/Model-definition-JSON-file.html#exclude-properties-from-base-model 

#### Related issues

<!--
Please use the following link syntaxes:

- connect to #49 (to reference issues in the current repository)
- connect to strongloop/loopback#49 (to reference issues in another repository)
-->

- connect to <link_to_referenced_issue>

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
